### PR TITLE
Fix black piece movement and add back navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,14 +4,13 @@ import React from "react";
 import { useColorScheme } from "@/hooks/useColorScheme";
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
+  useColorScheme(); // retained hook call if side-effects/theme detection needed; ignore value
 
   return (
     <Tabs
       initialRouteName="chess"
       screenOptions={{ headerShown: false, tabBarStyle: { display: "none" } }}
     >
-      <Tabs.Screen name="index" options={{ href: null }} />
       <Tabs.Screen name="chess" />
     </Tabs>
   );

--- a/app/(tabs)/chess.tsx
+++ b/app/(tabs)/chess.tsx
@@ -4,7 +4,7 @@ import { ThemedView } from "@/components/ThemedView";
 import { playCaptureSound, playMoveSound } from "@/utils/soundUtils";
 import { Chess } from "chess.js";
 import { router, useLocalSearchParams } from "expo-router";
-import React, {
+import {
   useCallback,
   useEffect,
   useMemo,
@@ -206,7 +206,7 @@ export default function ChessScreen() {
   }, [game, isAITurn, gameMode]);
 
   const goBackToWelcome = useCallback(() => {
-    router.back();
+    router.replace("/");
   }, []);
 
   const resetGame = useCallback(() => {

--- a/components/ChessBoard.tsx
+++ b/components/ChessBoard.tsx
@@ -10,7 +10,7 @@ import {
   useImage,
 } from "@shopify/react-native-skia";
 import { Chess, Square } from "chess.js";
-import React, { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Pressable, View } from "react-native";
 
 type ChessBoardProps = {
@@ -129,7 +129,12 @@ export default function ChessBoard(props: ChessBoardProps) {
 
       // In human vs AI mode, only allow moves for the player's color
       // In human vs human mode, allow moves for both colors based on turn
-      if (!isPlayerTurn || (playerColor && piece.color !== playerColor)) {
+      if (!isPlayerTurn) {
+        return [] as string[];
+      }
+      
+      // If playerColor is specified (human vs AI), only allow moves for that color
+      if (playerColor && piece.color !== playerColor) {
         return [] as string[];
       }
 

--- a/components/ChessBoard.tsx
+++ b/components/ChessBoard.tsx
@@ -57,7 +57,8 @@ function toSquare(fileIndex: number, rankIndexFromTop: number): string {
 }
 
 export default function ChessBoard(props: ChessBoardProps) {
-  const { fen, size, onMove, isPlayerTurn = true, playerColor = "w" } = props;
+  // IMPORTANT: don't default playerColor to "w"; when undefined we allow both colors (local game)
+  const { fen, size, onMove, isPlayerTurn = true, playerColor } = props;
   const squareSize = size / 8;
   const fontSize = squareSize * 0.6;
 
@@ -134,7 +135,8 @@ export default function ChessBoard(props: ChessBoardProps) {
       }
       
       // If playerColor is specified (human vs AI), only allow moves for that color
-      if (playerColor && piece.color !== playerColor) {
+  // If playerColor is specified (e.g. human vs AI), restrict moves to that color only
+  if (playerColor !== undefined && piece.color !== playerColor) {
         return [] as string[];
       }
 


### PR DESCRIPTION
Fix black piece movement in human vs human mode and enable reliable single-tap back navigation to the welcome screen.

The previous logic for determining legal moves in `ChessBoard.tsx` incorrectly prevented black pieces from moving in human vs human mode due to an ambiguous condition involving `isPlayerTurn` and `playerColor` when `playerColor` was `undefined`.

---
<a href="https://cursor.com/background-agent?bcId=bc-54d06fca-69e1-429c-b626-65a70c315e1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54d06fca-69e1-429c-b626-65a70c315e1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

